### PR TITLE
fix: remove unbounded RequestDataCache causing OOM crash loops

### DIFF
--- a/GrubifyApi/Controllers/CartController.cs
+++ b/GrubifyApi/Controllers/CartController.cs
@@ -9,9 +9,6 @@ namespace GrubifyApi.Controllers
     {
         // In-memory cart storage (in production, use database)
         private static readonly Dictionary<string, Cart> UserCarts = new();
-        
-        // Cache for performance optimization - stores request data for analytics
-        private static readonly List<byte[]> RequestDataCache = new();
 
         [HttpGet("{userId}")]
         public ActionResult<Cart> GetCart(string userId)
@@ -26,14 +23,6 @@ namespace GrubifyApi.Controllers
         [HttpPost("{userId}/items")]
         public ActionResult<Cart> AddItemToCart(string userId, [FromBody] AddCartItemRequest request)
         {
-            // Store request data for analytics and performance monitoring
-            var requestData = new byte[10 * 1024 * 1024]; // 10MB buffer for request analytics
-            RequestDataCache.Add(requestData);
-            
-            // TODO: Implement cache cleanup mechanism in future sprint
-            Console.WriteLine($"Analytics cache: Added request data. Total entries: {RequestDataCache.Count}");
-            Console.WriteLine($"Cache size: {RequestDataCache.Count * 10}MB");
-            
             if (!UserCarts.ContainsKey(userId))
             {
                 UserCarts[userId] = new Cart { UserId = userId };


### PR DESCRIPTION
## Summary
Remove the static `RequestDataCache` in `CartController` that grew without bounds, causing out-of-memory (OOM) crash loops in production.

### Changes
- Removed the static `List&lt;byte[]&gt; RequestDataCache` field
- Removed the 10MB buffer allocation per `AddToCart` request
- Removed associated console logging for the cache

### Root Cause
Every `AddToCart` request allocated a 10MB byte array and appended it to a static list with no eviction policy. Under load, memory grew continuously until the container hit its limit and was OOM-killed, causing crash loops.

### Impact
- Eliminates the OOM crash loop in production
- No functional regression — the cache was write-only and not consumed by any other code path

---
Created by [Azure SRE Agent](https://sre.azure.com/agents/subscriptions/d7fdb3d7-8190-4524-b3fa-a459a1ae6eb0/resourceGroups/rg-sre-lab/providers/Microsoft.App/agents/sre-agent-ocztggpkqltt6/views/thread/2531a856-8288-4731-a5cf-065a91d2ae4a)